### PR TITLE
Empty Subscriptions Bug

### DIFF
--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -183,10 +183,12 @@ module Spree
     end
 
     def last_skip
-      skips.last if skips.any? && skips.last.undo_at.nil? && skips.last.renewed_at.nil?
+      skips.last if active_skips?
     end
 
-    alias_attribute :skipping?, :last_skip
+    def skipping?
+      skips.last if active_skips? && skips.last.skip_at.to_date >= Date.today
+    end
 
     def can_skip
       # only allow skipping after date has pass
@@ -248,5 +250,10 @@ module Spree
       }))
     end
 
+    private
+
+    def active_skips?
+      skips.any? && skips.last.undo_at.nil? && skips.last.renewed_at.nil?
+    end
   end
 end

--- a/app/models/spree/subscription_skip_link.rb
+++ b/app/models/spree/subscription_skip_link.rb
@@ -1,0 +1,15 @@
+module Spree
+  class SubscriptionSkipLink < ActiveRecord::Base
+    belongs_to :user, class_name: 'Spree::User'
+    belongs_to :subscription, class_name: 'Spree::Subscription'
+
+    validates_presence_of   :user, :subscription
+    validates_uniqueness_of :token
+
+    private
+
+    def generate_token(prefix = 0)
+      "#{prefix}"-"#{SecureRandom.uuid}".freeze
+    end
+  end
+end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -3,6 +3,7 @@ module Spree
 
     def self.prepended(base)
       base.has_many :subscriptions
+      base.has_many :subscription_skip_links, class_name: 'Spree::SubscriptionSkipLink'
 
       base.has_many :log_entries, as: :source
     end

--- a/app/views/spree/admin/subscriptions/_sidebar.html.erb
+++ b/app/views/spree/admin/subscriptions/_sidebar.html.erb
@@ -21,12 +21,21 @@
       </dd>
       <dt>Skip order</dt>
       <dd><%= @subscription.skip_order_at ? 'Yes' : 'No' %></dd>
-      <dt>Skip order at</dt>
-      <dd>
-        <%= l(@subscription.skip_order_at, format: :subscription_date_format) if @subscription.skipping? %>
-        <%= link_to 'Skip', skip_admin_subscription_path(@subscription), method: :put if @subscription.can_skip? %>
-        <%= link_to 'Undo', undo_skip_admin_subscription_path(@subscription), method: :put if @subscription.skipping? %>
-      </dd>
+
+      <% if @subscription.skip_order_until %>
+        <dt>Summer skips:</dt>
+        <dd>
+          Yes
+          <%= link_to 'Undo', undo_skip_admin_subscription_path(@subscription), method: :put if @subscription.skipping? %>
+        </dd>
+      <% else %>
+        <dt>Skip order at</dt>
+        <dd>
+          <%= l(@subscription.skip_order_at, format: :subscription_date_format) if @subscription.skipping? %>
+          <%= link_to 'Skip', skip_admin_subscription_path(@subscription), method: :put if @subscription.can_skip? %>
+          <%= link_to 'Undo', undo_skip_admin_subscription_path(@subscription), method: :put if @subscription.skipping? %>
+        </dd>
+      <% end %>
       <dt>Failed renewals</dt>
       <dd><%= @subscription.failure_count %></dd>
     <% end %>

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -100,13 +100,17 @@
           <% end %>
         </td>
         <td>
-          <span class="state <%= subscription.orders.first.state.downcase %>">
-            <%= link_to subscription.orders.first.number, edit_admin_order_path(subscription.last_order), target: '_blank' %>
-          </span>
-          <br />
-          <%= l(subscription.last_order_date, format: :long)  %>
-          <br />
-          <%= subscription.shipping_method.name if subscription.shipment && subscription.shipment.shipping_method %>
+          <% if subscription.orders.any? %>
+            <span class="state <%= subscription.orders.first.state.downcase %>">
+              <%= link_to subscription.orders.first.number, edit_admin_order_path(subscription.last_order), target: '_blank' %>
+            </span>
+            <br />
+            <%= l(subscription.last_order_date, format: :long)  %>
+            <br />
+            <%= subscription.shipping_method.name if subscription.shipment && subscription.shipment.shipping_method %>
+          <% else %>
+            Subscription with empty orders.
+          <% end %>
         </td>
         <td class="align-center">
           <%= link_to(subscription.user.email, edit_admin_user_path(subscription.user), target: '_blank') if subscription.user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Spree::Core::Engine.add_routes do
         get :credit_card
         post :credit_card
       end
-      collection do 
+      collection do
         get :failures
       end
     end

--- a/db/migrate/20170522104058_add_skip_until_to_subscription_skip.rb
+++ b/db/migrate/20170522104058_add_skip_until_to_subscription_skip.rb
@@ -1,0 +1,5 @@
+class AddSkipUntilToSubscriptionSkip < ActiveRecord::Migration
+  def change
+    add_column :spree_subscription_skips, :skip_until, :datetime, default: nil
+  end
+end

--- a/db/migrate/20170522140029_create_subscription_skip_links.rb
+++ b/db/migrate/20170522140029_create_subscription_skip_links.rb
@@ -1,0 +1,15 @@
+class CreateSubscriptionSkipLinks < ActiveRecord::Migration
+  def change
+    create_table :spree_subscription_skip_links do |t|
+      t.references :user
+      t.references :subscription
+
+      t.string :token, default: nil
+      t.boolean :used, default: false
+      t.datetime :expires_at
+      t.timestamp
+    end
+
+    add_index :spree_subscription_skip_links, [:user_id, :subscription_id], name: 'subscription_skip_user_idx'
+  end
+end

--- a/db/migrate/20170524113137_add_interval_limit_to_subscription_skip_links.rb
+++ b/db/migrate/20170524113137_add_interval_limit_to_subscription_skip_links.rb
@@ -1,0 +1,5 @@
+class AddIntervalLimitToSubscriptionSkipLinks < ActiveRecord::Migration
+  def change
+    add_column :spree_subscription_skip_links, :interval_limit_at, :datetime
+  end
+end

--- a/db/migrate/20170530171626_add_source_to_skips.rb
+++ b/db/migrate/20170530171626_add_source_to_skips.rb
@@ -1,0 +1,5 @@
+class AddSourceToSkips < ActiveRecord::Migration
+  def change
+    add_column :spree_subscription_skips, :source, :string, default: nil
+  end
+end


### PR DESCRIPTION
Some of the subscriptions are being generated without being associated with any order.

This branch intends to mitigate the first symptom, which is, the index action is rendering a partial that is crashing as it tries to access the state of an order, not checking if it exists.

